### PR TITLE
Pad Season View cells so they are initially centered

### DIFF
--- a/Sources/Views/TVShows/Seasons/SeasonsView.swift
+++ b/Sources/Views/TVShows/Seasons/SeasonsView.swift
@@ -25,8 +25,8 @@ final class SeasonsView: UIView {
 			let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
 			let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-			let interSpacing: CGFloat = 35
-			let normalItemWidth: CGFloat = 250
+			let interSpacing: CGFloat = 24
+			let normalItemWidth: CGFloat = 252
 			let groupSize = NSCollectionLayoutSize(widthDimension: self.isTinyDevice ? .fractionalWidth(fraction) : .absolute(normalItemWidth), heightDimension: .fractionalHeight(fraction))
 			let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 			group.edgeSpacing = .init(leading: .fixed(interSpacing), top: .fixed(centerY), trailing: .fixed(interSpacing), bottom: nil)

--- a/Sources/Views/TVShows/Seasons/SeasonsView.swift
+++ b/Sources/Views/TVShows/Seasons/SeasonsView.swift
@@ -25,12 +25,18 @@ final class SeasonsView: UIView {
 			let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
 			let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-			let groupSize = NSCollectionLayoutSize(widthDimension: self.isTinyDevice ? .fractionalWidth(fraction) : .absolute(250), heightDimension: .fractionalHeight(fraction))
+			let interSpacing: CGFloat = 35
+			let normalItemWidth: CGFloat = 250
+			let groupSize = NSCollectionLayoutSize(widthDimension: self.isTinyDevice ? .fractionalWidth(fraction) : .absolute(normalItemWidth), heightDimension: .fractionalHeight(fraction))
 			let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-			group.edgeSpacing = .init(leading: nil, top: .fixed(centerY), trailing: .fixed(50), bottom: nil)
+			group.edgeSpacing = .init(leading: .fixed(interSpacing), top: .fixed(centerY), trailing: .fixed(interSpacing), bottom: nil)
+
+			let layoutContainerEffectiveWidth = layoutEnvironment.container.effectiveContentSize.width
+			let itemWidth = self.isTinyDevice ? layoutContainerEffectiveWidth * fraction : normalItemWidth
+			let horizontalSpacing = (layoutContainerEffectiveWidth - itemWidth) / 2 - interSpacing
 
 			let section = NSCollectionLayoutSection(group: group)
-			section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 70, bottom: 0, trailing: 0)
+			section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: horizontalSpacing, bottom: 0, trailing: horizontalSpacing)
 			section.visibleItemsInvalidationHandler = { items, offset, environment in
 				items.forEach { item in
 					let distanceFromCenter = abs((item.frame.midX - offset.x) - environment.container.contentSize.width / 2)


### PR DESCRIPTION
- Balance `leading` and `trailing` values for both `group.edgeSpacing` and `section.contentInsets`. This should prevent uneven spacing in the UI.
- Use `section.contentInsets` to provide enough padding such that each cell can fit in the center
- Use `group.edgeSpacing` to provide a consistent amount of space between cells

Additionally, this PR changes two constants:
1. the "normal" cell width was `250`, this PR changes to be `252` so that it's modulo congruent by 4
2. the space between cells was `50`, this PR changes it to be `48` (`interSpacing * 2`) so that's modulo congruent by 4