### PR TITLE
Calculate Seasons View cell dimensions as a ratio of container height

### DIFF
--- a/Sources/Views/TVShows/Seasons/SeasonsView.swift
+++ b/Sources/Views/TVShows/Seasons/SeasonsView.swift
@@ -9,31 +9,31 @@ final class SeasonsView: UIView {
 
 	private let viewModel: SeasonsViewViewModel
 
-	private var isTinyDevice: Bool {
-		if UIScreen.main.nativeBounds.size.height <= 1334 { return true }
-		return false
-	}
-
 	private lazy var compositionalLayout: UICollectionViewCompositionalLayout = {
 		let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, layoutEnvironment -> NSCollectionLayoutSection? in
 			guard let self else { return nil }
 
-			let fraction: CGFloat = 1 / 2
-			let cellCenterY: CGFloat = self.isTinyDevice ? 130.75 : 197.25
-			let centerY: CGFloat = layoutEnvironment.container.contentSize.height / 2 - cellCenterY
+			let effectiveContainerSize = layoutEnvironment.container.effectiveContentSize
+
+			let widthFraction: CGFloat = 3 / 5 // ratio of cell width to collection view width
+			let heightFraction: CGFloat = 1 / 2 // ratio of cell height to collection view height
+			
+			let layoutContainerEffectiveHeight = effectiveContainerSize.height
+			let itemHeight = layoutContainerEffectiveHeight * heightFraction
+			let verticalSpacing: CGFloat = (layoutEnvironment.container.contentSize.height - itemHeight) / 2
 
 			let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
 			let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
 			let interSpacing: CGFloat = 24
 			let normalItemWidth: CGFloat = 252
-			let groupSize = NSCollectionLayoutSize(widthDimension: self.isTinyDevice ? .fractionalWidth(fraction) : .absolute(normalItemWidth), heightDimension: .fractionalHeight(fraction))
+			let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(widthFraction), heightDimension: .fractionalHeight(heightFraction))
 			let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-			group.edgeSpacing = .init(leading: .fixed(interSpacing), top: .fixed(centerY), trailing: .fixed(interSpacing), bottom: nil)
+			group.edgeSpacing = .init(leading: .fixed(interSpacing), top: .fixed(verticalSpacing), trailing: .fixed(interSpacing), bottom: nil)
 
-			let layoutContainerEffectiveWidth = layoutEnvironment.container.effectiveContentSize.width
-			let itemWidth = self.isTinyDevice ? layoutContainerEffectiveWidth * fraction : normalItemWidth
-			let horizontalSpacing = (layoutContainerEffectiveWidth - itemWidth) / 2 - interSpacing
+			let layoutContainerEffectiveWidth = effectiveContainerSize.width
+			let itemWidth = layoutContainerEffectiveWidth * widthFraction
+			let horizontalSpacing = (layoutEnvironment.container.contentSize.width - itemWidth) / 2 - interSpacing
 
 			let section = NSCollectionLayoutSection(group: group)
 			section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: horizontalSpacing, bottom: 0, trailing: horizontalSpacing)

--- a/Sources/Views/TVShows/Seasons/SeasonsView.swift
+++ b/Sources/Views/TVShows/Seasons/SeasonsView.swift
@@ -13,25 +13,39 @@ final class SeasonsView: UIView {
 		let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, layoutEnvironment -> NSCollectionLayoutSection? in
 			guard let self else { return nil }
 
-			let containerSize = layoutEnvironment.container.effectiveContentSize
+			let containerSize = layoutEnvironment.container.contentSize
 			let effectiveContainerSize = layoutEnvironment.container.effectiveContentSize
 
-			let heightFraction: CGFloat = 0.6 // ratio of cell height to collection view height
-			// the poster images have an aspect ratio of about 3:2
-			let widthFraction: CGFloat = heightFraction * 2/3 // ratio of cell width to collection view height
+			let effectiveContainerHeight = effectiveContainerSize.height
+			// the space on each side of a cell;
+			// the total space between two cells would be twice this value
+			let interSpacing: CGFloat = 24
+			let cellAspectRatio: CGFloat = 3/2 // the poster images have an aspect ratio of about 3:2
+			let neighborVisibleRatio: CGFloat = 0.15 // how much of the neighboring cells we should see
+			// the horizontal layout should look (at the minimum) as follows:
+			//   1. `cellWidth * neighborVisibleRatio` of the leading cell
+			//   2. `interSpacing * 2` padding
+			//   3. `cellWidth` of the center cell
+			//   4. `interSpacing * 2` padding
+			//   5. `cellWidth * neighborVisibleRatio` of the trailing cell
+			// to satisfy this, we describe the following constraint:
+			//   ((cellWidth * neighborVisibleRatio) * 2 + (interSpacing * 2) * 2 + cellWidth) <= effectiveContainerSize.width
+			// to solve for `cellWidth`:
+			//   cellWidth <= (effectiveContainerSize.width - interSpacing * 4) / (neighborVisibleRatio * 2 + 1)
 
-			let layoutContainerEffectiveHeight = effectiveContainerSize.height
+			let maxCellWidth: CGFloat = (effectiveContainerSize.width - interSpacing * 4) / (neighborVisibleRatio * 2 + 1)
+			let maxCellRatio: CGFloat = maxCellWidth / effectiveContainerHeight
+			let widthFraction: CGFloat = min(0.4, maxCellRatio) // ratio of cell width to collection view height
+			let heightFraction: CGFloat = widthFraction * cellAspectRatio // ratio of cell height to collection view height
+
 			let derivedCellSize = CGSize(
-				width: layoutContainerEffectiveHeight * widthFraction,
-				height: layoutContainerEffectiveHeight * heightFraction
+				width: effectiveContainerHeight * widthFraction,
+				height: effectiveContainerHeight * heightFraction
 			)
 
 			let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
 			let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-			// the space on each side of a cell;
-			// the total space between two cells would be twice this value
-			let interSpacing: CGFloat = 24
 			// the spacing needed above the group such that the the group appears vertically centered
 			let verticalSpacing: CGFloat = (containerSize.height - derivedCellSize.height) / 2
 			// the spacing needed on each of the horizontal edges so that edge cells may be horizontally centered in the group

--- a/Sources/Views/TVShows/Seasons/SeasonsView.swift
+++ b/Sources/Views/TVShows/Seasons/SeasonsView.swift
@@ -13,27 +13,33 @@ final class SeasonsView: UIView {
 		let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, layoutEnvironment -> NSCollectionLayoutSection? in
 			guard let self else { return nil }
 
+			let containerSize = layoutEnvironment.container.effectiveContentSize
 			let effectiveContainerSize = layoutEnvironment.container.effectiveContentSize
-
-			let widthFraction: CGFloat = 3 / 5 // ratio of cell width to collection view width
-			let heightFraction: CGFloat = 1 / 2 // ratio of cell height to collection view height
 			
+			let heightFraction: CGFloat = 0.6 // ratio of cell height to collection view height
+			// the poster images have an aspect ratio of about 3:2
+			let widthFraction: CGFloat = heightFraction * 2/3 // ratio of cell width to collection view height
+
 			let layoutContainerEffectiveHeight = effectiveContainerSize.height
-			let itemHeight = layoutContainerEffectiveHeight * heightFraction
-			let verticalSpacing: CGFloat = (layoutEnvironment.container.contentSize.height - itemHeight) / 2
+			let derivedCellSize = CGSize(
+				width: layoutContainerEffectiveHeight * widthFraction,
+				height: layoutContainerEffectiveHeight * heightFraction
+			)
 
 			let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
 			let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
+			// the space on each side of a cell;
+			// the total space between two cells would be twice this value
 			let interSpacing: CGFloat = 24
-			let normalItemWidth: CGFloat = 252
-			let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(widthFraction), heightDimension: .fractionalHeight(heightFraction))
+			// the spacing needed above the group such that the the group appears vertically centered
+			let verticalSpacing: CGFloat = (containerSize.height - derivedCellSize.height) / 2
+			// the spacing needed on each of the horizontal edges so that edge cells may be horizontally centered in the group
+			let horizontalSpacing = (containerSize.width - derivedCellSize.width) / 2 - interSpacing
+
+			let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalHeight(widthFraction), heightDimension: .fractionalHeight(heightFraction))
 			let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 			group.edgeSpacing = .init(leading: .fixed(interSpacing), top: .fixed(verticalSpacing), trailing: .fixed(interSpacing), bottom: nil)
-
-			let layoutContainerEffectiveWidth = effectiveContainerSize.width
-			let itemWidth = layoutContainerEffectiveWidth * widthFraction
-			let horizontalSpacing = (layoutEnvironment.container.contentSize.width - itemWidth) / 2 - interSpacing
 
 			let section = NSCollectionLayoutSection(group: group)
 			section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: horizontalSpacing, bottom: 0, trailing: horizontalSpacing)

--- a/Sources/Views/TVShows/Seasons/SeasonsView.swift
+++ b/Sources/Views/TVShows/Seasons/SeasonsView.swift
@@ -15,7 +15,7 @@ final class SeasonsView: UIView {
 
 			let containerSize = layoutEnvironment.container.effectiveContentSize
 			let effectiveContainerSize = layoutEnvironment.container.effectiveContentSize
-			
+
 			let heightFraction: CGFloat = 0.6 // ratio of cell height to collection view height
 			// the poster images have an aspect ratio of about 3:2
 			let widthFraction: CGFloat = heightFraction * 2/3 // ratio of cell width to collection view height


### PR DESCRIPTION
The motivation for this PR is in two parts:
1. remove the magic numbers that make up `cellCenterY` which attempt to find the `midY` value of the cell.
2. remove `isTinyDevice` to further improve support across devices sizes.

This PR describes the maximum cell ratio which would allow neighboring cells to be visible within the layout container. The code then selects `0.4` or the computed maximum ratio. We selected `0.4` for the unconstrained ratio as it results in comfortable vertical padding (see iPad mini landscape screenshot below).

When tuning this `0.4` value it should be noted that it is multiplied by `cellAspectRatio = 1.5` and up to `maxScale = 1.2`, so by a total of `1.5 * 1.2 = 1.8`. The final result (e.g. `0.4 * 1.8` must be less than `1`, otherwise the content will be cut off (vertically).

---

### Screenshots

iPod touch (7th generation):

<img src="https://github.com/Luki120/Areesha/assets/40723121/8d844791-8690-4a14-9c29-6da566cc9f5c" width="50%" alt="iPod touch (7th generation)" />


iPhone Xʀ:

<img src="https://github.com/Luki120/Areesha/assets/40723121/b272e48d-d891-4b18-a816-3cbe81f79be6" width="50%" alt="iPhone Xʀ" />


iPad mini (6th generation) portrait:

<img src="https://github.com/Luki120/Areesha/assets/40723121/95bd4216-116f-49e2-ae14-2d3a810661b0" width="50%" alt="iPad mini (6th generation) portrait" />


iPad mini (6th generation) landscape:

<img src="https://github.com/Luki120/Areesha/assets/40723121/76f2a275-bcfd-4981-bf4e-4da471aa870d" width="80%" alt="iPad mini (6th generation) landscape" />